### PR TITLE
Release v0.1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "qq-album-download",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "qq-album-download",
   "author": "lihengdao",
   "main": "main.js",


### PR DESCRIPTION
Release v0.1.6.

Bumps package metadata so tag-triggered GitHub Actions builds and publishes release artifacts online.